### PR TITLE
Fix gitsigns config

### DIFF
--- a/lua/sohooo/gitsigns.lua
+++ b/lua/sohooo/gitsigns.lua
@@ -1,24 +1,26 @@
 -- Gitsigns
-local present, gitsigns = pcall(require, "gitsigns")
-if not present then return end
+local present, gitsigns = pcall(require, 'gitsigns')
+if not present then
+  return
+end
 
 gitsigns.setup {
   signs = {
-    add          = { hl = 'GitSignsAdd'   , text = '│', numhl='GitSignsAddNr'   , linehl='GitSignsAddLn'    },
-    change       = { hl = 'GitSignsChange', text = '│', numhl='GitSignsChangeNr', linehl='GitSignsChangeLn' },
-    delete       = { hl = 'GitSignsDelete', text = '_', numhl='GitSignsDeleteNr', linehl='GitSignsDeleteLn' },
-    topdelete    = { hl = 'GitSignsDelete', text = '‾', numhl='GitSignsDeleteNr', linehl='GitSignsDeleteLn' },
-    changedelete = { hl = 'GitSignsChange', text = '~', numhl='GitSignsChangeNr', linehl='GitSignsChangeLn' },
-    untracked    = { hl = 'GitSignsAdd'   , text = '│', numhl='GitSignsAddNr'   , linehl='GitSignsAddLn'    },
+    add = { hl = 'GitSignsAdd', text = '│', numhl = 'GitSignsAddNr', linehl = 'GitSignsAddLn' },
+    change = { hl = 'GitSignsChange', text = '│', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn' },
+    delete = { hl = 'GitSignsDelete', text = '_', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn' },
+    topdelete = { hl = 'GitSignsDelete', text = '‾', numhl = 'GitSignsDeleteNr', linehl = 'GitSignsDeleteLn' },
+    changedelete = { hl = 'GitSignsChange', text = '~', numhl = 'GitSignsChangeNr', linehl = 'GitSignsChangeLn' },
+    untracked = { hl = 'GitSignsAdd', text = '│', numhl = 'GitSignsAddNr', linehl = 'GitSignsAddLn' },
     -- untracked    = { hl = 'GitSignsAdd'   , text = '┆', numhl='GitSignsAddNr'   , linehl='GitSignsAddLn'    },
   },
-  signcolumn = true,  -- Toggle with `:Gitsigns toggle_signs`
-  numhl      = false, -- Toggle with `:Gitsigns toggle_numhl`
-  linehl     = false, -- Toggle with `:Gitsigns toggle_linehl`
-  word_diff  = false, -- Toggle with `:Gitsigns toggle_word_diff`
+  signcolumn = true, -- Toggle with `:Gitsigns toggle_signs`
+  numhl = false, -- Toggle with `:Gitsigns toggle_numhl`
+  linehl = false, -- Toggle with `:Gitsigns toggle_linehl`
+  word_diff = false, -- Toggle with `:Gitsigns toggle_word_diff`
   watch_gitdir = {
     interval = 1000,
-    follow_files = true
+    follow_files = true,
   },
   attach_to_untracked = true,
   current_line_blame = true, -- Toggle with `:Gitsigns toggle_current_line_blame`
@@ -40,11 +42,14 @@ gitsigns.setup {
     style = 'minimal',
     relative = 'cursor',
     row = 0,
-    col = 1
+    col = 1,
   },
-  yadm = {
-    enable = vim.fn.executable("yadm") == 1,
-  },
+  worktrees = vim.fn.executable 'yadm' == 1 and {
+    {
+      toplevel = vim.env.HOME,
+      gitdir = vim.env.HOME .. '/.local/share/yadm/repo.git',
+    },
+  } or nil,
 }
 
 -- require('gitsigns').setup {
@@ -56,4 +61,3 @@ gitsigns.setup {
 --   --   changedelete = { hl = 'GitGutterChange', text = '~' },
 --   -- },
 -- }
-


### PR DESCRIPTION
## Summary
- remove deprecated `yadm` config from gitsigns
- use `worktrees` setting when yadm is available

## Testing
- `stylua lua/sohooo/gitsigns.lua`
- `apt-get update`


------
https://chatgpt.com/codex/tasks/task_e_688cc2e490e88323b8a82f9994f0c294