### PR TITLE
feat(codex): Add headless startup test

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ Search and replace is like nothing you've ever experienced, thanks to `Telescope
 *  fenced code blocks
 
 
+## Testing
+
+Run `./tests/run.sh` to check the configuration in a headless Neovim instance. The
+script exits with an error if any warnings or errors occur.
+
 ## Misc
 
 ### Terminal

--- a/tests/headless_startup.sh
+++ b/tests/headless_startup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_PATH="$SCRIPT_DIR/../init.lua"
+
+output=$(nvim --headless -u "$CONFIG_PATH" -c 'qa' 2>&1 || true)
+
+if echo "$output" | grep -iE 'error|warning'; then
+  echo "$output"
+  echo "Headless startup produced errors or warnings" >&2
+  exit 1
+else
+  echo "$output"
+  echo "Headless startup succeeded without errors or warnings"
+fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+DIR="$(dirname "$0")"
+
+bash "$DIR/headless_startup.sh"


### PR DESCRIPTION
## Summary
- add a shell script `tests/headless_startup.sh` to verify the config
- add `tests/run.sh` helper
- document the new test in `README.md`

## Testing
- `./tests/run.sh` *(fails: Headless startup produced errors or warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688cc45176988323b64bc57f892bcd9e