### PR TITLE
fix(codex): headless startup script to load init.lua and detect startup errors

### DIFF
--- a/tests/headless_startup.sh
+++ b/tests/headless_startup.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd $SCRIPT_DIR/..
+cd "$SCRIPT_DIR/.."
 
 # Set XDG variables to ensure proper runtime paths
 export XDG_CONFIG_HOME="$(pwd)"
 export XDG_DATA_HOME="$(pwd)"
 export XDG_CACHE_HOME="$(pwd)/cache"
 
-output=$(nvim --headless -c 'qa' 2>&1 || true)
+# Run Neovim with the repository's init.lua and capture output
+set +e
+output=$(nvim --headless -u init.lua -c 'qa' 2>&1)
+status=$?
+set -e
 
-if echo "$output" | grep -iE 'error|warning'; then
+if [ $status -ne 0 ] || echo "$output" | grep -iE 'error|warning' >/dev/null; then
   echo "$output"
-  echo "Headless startup produced errors or warnings" >&2
+  echo "Headless startup failed with errors or warnings" >&2
   exit 1
 else
   echo "$output"
   echo "Headless startup succeeded without errors or warnings"
 fi
 
-cd -
+cd - >/dev/null


### PR DESCRIPTION
## Summary
- Ensure headless_startup.sh explicitly loads repository init.lua
- Fail fast when Neovim reports errors or warnings during startup

## Testing
- `tests/run.sh` *(fails: module 'sohooo/misc' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688df346911883239f617b373cbcc545