### PR TITLE
docs: add conventional commits guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,11 @@
 ## Commit Guidelines
 - Write clear, concise commit messages in the imperative mood.
 
+## Conventional Commits
+- Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for pull request titles and commit messages.
+- Format messages as `<type>(optional scope): <description>` in the imperative mood.
+- Use lowercase types such as `feat`, `fix`, `docs`, `refactor`, `test`, and `chore`.
+
 ## Testing
 Run the headless startup test to verify that the configuration loads without errors or warnings:
 


### PR DESCRIPTION
## Summary
- document requirement to format PR titles and commit messages using Conventional Commits

## Testing
- `tests/run.sh` *(fails: Neovim archive download was not a gzip)*

------
https://chatgpt.com/codex/tasks/task_e_688e00e5567c8323aacf029d166021ec