### PR TITLE
chore: add plugin upgrade scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: update-plugins verify-plugins upgrade
+
+update-plugins:
+	bash scripts/update-plugins.sh
+
+verify-plugins:
+	bash scripts/verify-plugins.sh
+
+upgrade: update-plugins verify-plugins

--- a/scripts/update-plugins.sh
+++ b/scripts/update-plugins.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export XDG_CONFIG_HOME="$ROOT"
+export XDG_DATA_HOME="$ROOT"
+export XDG_CACHE_HOME="$ROOT/cache"
+
+nvim --headless "+Lazy! update" +qa
+

--- a/scripts/verify-plugins.sh
+++ b/scripts/verify-plugins.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+bash "$ROOT/tests/run.sh"
+


### PR DESCRIPTION
## Summary
- add Makefile target to update and verify Lazy plugins
- add scripts to update plugins and run startup tests

## Testing
- `make verify-plugins`


------
https://chatgpt.com/codex/tasks/task_e_688e2114d9588323b90e0ad40f479187